### PR TITLE
Support POST updates and make typings more specific

### DIFF
--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -3,6 +3,7 @@ import * as RDF from "rdf-js";
 import {Parser as SparqlParser} from "sparqljs";
 import {ISettings, SparqlJsonParser} from "sparqljson-parse";
 import {SparqlXmlParser} from "sparqlxml-parse";
+import {Readable} from "stream";
 
 // tslint:disable:no-var-requires
 const n3 = require('n3');
@@ -100,7 +101,7 @@ export class SparqlEndpointFetcher {
    * @param {string} query    A SPARQL query string.
    * @return {Promise<Stream>} A stream of triples.
    */
-  public async fetchTriples(endpoint: string, query: string): Promise<RDF.Stream> {
+  public async fetchTriples(endpoint: string, query: string): Promise<Readable & RDF.Stream> {
     const rawStream = (await this.fetchRawStream(endpoint, query, SparqlEndpointFetcher.CONTENTTYPE_TURTLE))[1];
     return rawStream.pipe(new n3.StreamParser({ format: SparqlEndpointFetcher.CONTENTTYPE_TURTLE }));
   }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.0",
     "@types/minimist": "^1.2.0",
+    "@types/n3": "^1.4.4",
     "@types/sparqljs": "^3.0.1",
     "arrayify-stream": "^1.0.0",
     "coveralls": "^3.0.0",

--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -25,6 +25,7 @@ describe('SparqlEndpointFetcher', () => {
     const queryAsk = 'ASK WHERE { ?s ?p ?o }';
     const queryConstruct = 'CONSTRUCT WHERE { ?s ?p ?o }';
     const queryDescribe = 'DESCRIBE <http://ex.org>';
+    const queryDelete = 'DELETE WHERE { ?s ?p ?o }';
 
     let fetchCb;
     let fetcher;
@@ -154,6 +155,28 @@ describe('SparqlEndpointFetcher', () => {
         return expect((await fetcherThis.fetchRawStream(endpoint, querySelect, 'myacceptheader'))[0])
           .toEqual('abc');
       });
+    });
+
+    describe('#fetchUpdate', () => {
+      it('should use POST and the correct content-type', async () => {
+        const fetchCbThis: jest.Mock<Promise<Response>, any[]> = jest.fn(() => Promise.resolve(<Response> {
+          body: streamifyString(`abc`),
+          headers: new Headers(),
+          ok: true,
+          status: 200,
+          statusText: 'Ok!',
+        }));
+        const fetcherThis = new SparqlEndpointFetcher({ fetch: fetchCbThis });
+        await expect(fetcherThis.fetchUpdate(endpoint, queryDelete)).resolves.toBeUndefined();
+        expect(fetchCbThis.mock.calls[0][0]).toBe(endpoint);
+        expect(fetchCbThis.mock.calls[0][1]).toMatchObject({
+          method: 'POST',
+          headers: {
+            'content-type': 'application/sparql-update',
+          },
+          body: queryDelete,
+        });
+      })
     });
 
     describe('#fetchBindings', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -572,6 +572,14 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
+"@types/n3@^1.4.4":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@types/n3/-/n3-1.4.4.tgz#ed4f58200766ffc850d281e28c566eacb2b0b592"
+  integrity sha512-xsWfwyDh0uAH0CXvwqe9vb2UEDafMjRez/pB7yZwbWpd9Olw2wdxaL32FtdHjmmFE6b9i+j249JfRyZnvWkoqg==
+  dependencies:
+    "@types/node" "*"
+    "@types/rdf-js" "*"
+
 "@types/node@*":
   version "14.10.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.2.tgz#9b47a2c8e4dabd4db73b57e750b24af689600514"


### PR DESCRIPTION
This is a 2-in-1, but seemed easier to do it like this then have 2 separate ones that needed to be rebased afterwards. Can always remove one of the commits if not wanted.

So the first thing is adding a function to do updates. The specific difference is that POST gets used here since query updates can potentially get quite large if many triples need to be added at the same time.

The second one is to update the typings of `fetchBindings` to return a Readable since that is also what N3.js returns (and would make my life a bit easier since piping something that is only an RDF.Stream is somewhat annoying).