### PR TITLE
Feature/get update types

### DIFF
--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -72,7 +72,7 @@ export class SparqlEndpointFetcher {
    */
   public getUpdateTypes(query: string): 'UNKNOWN' | IUpdateTypes {
     const parsedQuery = new SparqlParser().parse(query);
-    
+
     if (parsedQuery.type === 'update') {
       const operations: IUpdateTypes = {};
 
@@ -219,5 +219,5 @@ export interface ISparqlResultsParser {
 }
 
 export type IUpdateTypes = {
-  [K in ManagementOperation['type'] | InsertDeleteOperation['updateType']]?: Boolean;
+  [K in ManagementOperation['type'] | InsertDeleteOperation['updateType']]?: boolean;
 };

--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -1,9 +1,9 @@
 import "cross-fetch/polyfill";
 import * as RDF from "rdf-js";
-import {Parser as SparqlParser} from "sparqljs";
-import {ISettings, SparqlJsonParser} from "sparqljson-parse";
-import {SparqlXmlParser} from "sparqlxml-parse";
-import {Readable} from "stream";
+import { Parser as SparqlParser } from "sparqljs";
+import { ISettings, SparqlJsonParser } from "sparqljson-parse";
+import { SparqlXmlParser } from "sparqlxml-parse";
+import { Readable } from "stream";
 
 // tslint:disable:no-var-requires
 const n3 = require('n3');
@@ -23,7 +23,7 @@ export class SparqlEndpointFetcher {
   public static CONTENTTYPE_TURTLE: string = 'text/turtle';
 
   public readonly fetchCb?: (input?: Request | string, init?: RequestInit) => Promise<Response>;
-  public readonly sparqlParsers: {[contentType: string]: ISparqlResultsParser};
+  public readonly sparqlParsers: { [contentType: string]: ISparqlResultsParser };
   public readonly sparqlJsonParser: SparqlJsonParser;
   public readonly sparqlXmlParser: SparqlXmlParser;
 
@@ -61,6 +61,46 @@ export class SparqlEndpointFetcher {
     return parsedQuery.type === 'query'
       ? (parsedQuery.queryType === 'DESCRIBE' ? 'CONSTRUCT' : parsedQuery.queryType) : "UNKNOWN";
   }
+
+  /**
+   * Get the query type of the given update query.
+   *
+   * This will parse the update query and thrown an exception on syntax errors.
+   *
+   * @param {string} query An update query.
+   * @return {'UNKNOWN' | {
+   *  insertDelete: ('insert' | 'delete' | 'deletewhere' | 'insertdelete')[];
+   *  management: ('copy' | 'move' | 'add' | 'load' | 'create' | 'clear' | 'drop')[]
+   * }} The included update operations.
+   */
+  public getUpdateTypes(query: string): 'UNKNOWN' | {
+    insertDelete: ('insert' | 'delete' | 'deletewhere' | 'insertdelete')[];
+    management: ('copy' | 'move' | 'add' | 'load' | 'create' | 'clear' | 'drop')[]
+  } {
+    const parsedQuery = new SparqlParser().parse(query);
+
+    if (parsedQuery.type === 'update') {
+      const insertDelete: ('insert' | 'delete' | 'deletewhere' | 'insertdelete')[] = [];
+      const management: ('copy' | 'move' | 'add' | 'load' | 'create' | 'clear' | 'drop')[] = [];
+
+      for (const update of parsedQuery.updates) {
+        if ('type' in update && !management.includes(update.type)) {
+          management.push(update.type);
+        }
+        if ('updateType' in update && !insertDelete.includes(update.updateType)) {
+          insertDelete.push(update.updateType);
+        }
+      }
+
+      return {
+        insertDelete,
+        management
+      }
+
+    } else {
+      return "UNKNOWN"
+    };
+  };
 
   /**
    * Send a SELECT query to the given endpoint URL and return the resulting bindings stream.
@@ -172,7 +212,7 @@ export class SparqlEndpointFetcher {
       throw new Error('Invalid SPARQL endpoint (' + simpleUrl + ') response: ' + httpResponse.statusText);
     }
 
-    return [ contentType, responseStream ];
+    return [contentType, responseStream];
   }
 }
 

--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -1,9 +1,9 @@
 import "cross-fetch/polyfill";
 import * as RDF from "rdf-js";
-import { Parser as SparqlParser } from "sparqljs";
-import { ISettings, SparqlJsonParser } from "sparqljson-parse";
-import { SparqlXmlParser } from "sparqlxml-parse";
-import { Readable } from "stream";
+import {Parser as SparqlParser} from "sparqljs";
+import {ISettings, SparqlJsonParser} from "sparqljson-parse";
+import {SparqlXmlParser} from "sparqlxml-parse";
+import {Readable} from "stream";
 
 // tslint:disable:no-var-requires
 const n3 = require('n3');
@@ -23,7 +23,7 @@ export class SparqlEndpointFetcher {
   public static CONTENTTYPE_TURTLE: string = 'text/turtle';
 
   public readonly fetchCb?: (input?: Request | string, init?: RequestInit) => Promise<Response>;
-  public readonly sparqlParsers: { [contentType: string]: ISparqlResultsParser };
+  public readonly sparqlParsers: {[contentType: string]: ISparqlResultsParser};
   public readonly sparqlJsonParser: SparqlJsonParser;
   public readonly sparqlXmlParser: SparqlXmlParser;
 
@@ -86,9 +86,8 @@ export class SparqlEndpointFetcher {
       for (const update of parsedQuery.updates) {
         if ('type' in update && !management.includes(update.type)) {
           management.push(update.type);
-        }
-        if ('updateType' in update && !insertDelete.includes(update.updateType)) {
-          insertDelete.push(update.updateType);
+        } else if ('updateType' in update && !insertDelete.includes(update.updateType)) {
+          insertDelete.push(update.updateType)
         }
       }
 
@@ -212,7 +211,7 @@ export class SparqlEndpointFetcher {
       throw new Error('Invalid SPARQL endpoint (' + simpleUrl + ') response: ' + httpResponse.statusText);
     }
 
-    return [contentType, responseStream];
+    return [ contentType, responseStream ];
   }
 }
 

--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -30,6 +30,7 @@ describe('SparqlEndpointFetcher', () => {
     const queryDelete = 'DELETE WHERE { ?s ?p ?o }';
     const queryInsert = 'INSERT { ?s ?p ?o } WHERE {}';
     const updateDeleteData = prefixes + 'DELETE DATA { GRAPH <http://example.org/g1> { :a foaf:knows :b } }';
+    const updateDeleteData2 = prefixes + 'DELETE DATA { GRAPH <http://example.org/g1> { :b foaf:knows :c } }';
     const updateInsertData = prefixes + 'INSERT DATA { GRAPH <http://example.org/g1> { :Alice foaf:knows :Bob } }';
     const updateMove = prefixes + 'MOVE DEFAULT TO :g1';
     const updateAdd = 'ADD SILENT GRAPH <http://www.example.com/g1> TO DEFAULT'
@@ -118,6 +119,13 @@ describe('SparqlEndpointFetcher', () => {
         });
       });
 
+      it('should detect a delete data query for 2 update operations', () => {
+        return expect(fetcher.getUpdateTypes(updateDeleteData + ';' + updateDeleteData2)).toEqual({
+          management: [],
+          insertDelete: [ 'delete' ]
+        });
+      });
+
       it('should detect an insert data query', () => {
         return expect(fetcher.getUpdateTypes(updateInsertData)).toEqual({
           management: [],
@@ -127,6 +135,13 @@ describe('SparqlEndpointFetcher', () => {
 
       it('should detect a combined insert and delete data query', () => {
         return expect(fetcher.getUpdateTypes(updateInsertData + ';' + updateDeleteData)).toEqual({
+          management: [],
+          insertDelete: [ 'insert', 'delete' ]
+        });
+      });
+
+      it('should detect a combined insert and delete data query (2 delete queries)', () => {
+        return expect(fetcher.getUpdateTypes(updateInsertData + ';' + updateDeleteData + ';' + updateDeleteData)).toEqual({
           management: [],
           insertDelete: [ 'insert', 'delete' ]
         });

--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -100,78 +100,73 @@ describe('SparqlEndpointFetcher', () => {
 
       it('should detect an insertdelete query', () => {
         return expect(fetcher.getUpdateTypes(queryInsert)).toEqual({
-          management: [],
-          insertDelete: [ 'insertdelete' ]
+          insertdelete: true
         });
       });
 
       it('should detect a delete query', () => {
         return expect(fetcher.getUpdateTypes(queryDelete)).toEqual({
-          management: [],
-          insertDelete: [ 'deletewhere' ]
+          deletewhere: true
         });
       });
 
       it('should detect a delete data query', () => {
         return expect(fetcher.getUpdateTypes(updateDeleteData)).toEqual({
-          management: [],
-          insertDelete: [ 'delete' ]
+          delete: true
         });
       });
 
       it('should detect a delete data query for 2 update operations', () => {
         return expect(fetcher.getUpdateTypes(updateDeleteData + ';' + updateDeleteData2)).toEqual({
-          management: [],
-          insertDelete: [ 'delete' ]
+          delete: true
         });
       });
 
       it('should detect an insert data query', () => {
         return expect(fetcher.getUpdateTypes(updateInsertData)).toEqual({
-          management: [],
-          insertDelete: [ 'insert' ]
+          insert: true
         });
       });
 
       it('should detect a combined insert and delete data query', () => {
         return expect(fetcher.getUpdateTypes(updateInsertData + ';' + updateDeleteData)).toEqual({
-          management: [],
-          insertDelete: [ 'insert', 'delete' ]
+          insert: true,
+          delete: true
         });
       });
 
       it('should detect a combined insert and delete data query (2 delete queries)', () => {
         return expect(fetcher.getUpdateTypes(updateInsertData + ';' + updateDeleteData + ';' + updateDeleteData)).toEqual({
-          management: [],
-          insertDelete: [ 'insert', 'delete' ]
+          insert: true,
+          delete: true
         });
       });
 
       it('should detect a move operation', () => {
         return expect(fetcher.getUpdateTypes(updateMove)).toEqual({
-          management: [ 'move' ],
-          insertDelete: []
+          move: true
         });
       });
 
       it('should detect a add operation', () => {
         return expect(fetcher.getUpdateTypes(updateAdd)).toEqual({
-          management: [ 'add' ],
-          insertDelete: []
+          add: true
         });
       });
 
       it('should detect a combined move and add operation', () => {
         return expect(fetcher.getUpdateTypes(updateMove + ';' + updateAdd)).toEqual({
-          management: [ 'move', 'add' ],
-          insertDelete: []
+          move: true,
+          add: true
         });
       });
 
       it('should detect a combined move, add, insert and delete operations', () => {
         return expect(fetcher.getUpdateTypes(updateMove + ';' + updateAdd + ';' + updateInsertData + ';' + updateDeleteData)).toEqual({
-          management: [ 'move', 'add' ],
-          insertDelete: [ 'insert', 'delete' ]
+          move: true,
+          add: true,
+          insert: true,
+          delete: true
         });
       });
 


### PR DESCRIPTION
This is designed to be the counterpart of `getQueryType` for update operations. I'm using it a comunica actor `actor-query-operation-update-sparql-endpoint`. (I'll create a PR to comunica with that and other update actors soon).