### PR TITLE
Set Content-Length header on requests

### DIFF
--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -181,6 +181,7 @@ export class SparqlEndpointFetcher {
       headers.append('Content-Type', 'application/x-www-form-urlencoded');
       body = new URLSearchParams();
       body.set('query', query);
+      headers.append('Content-Length', body.toString().length.toString());
     }
 
     return this.handleFetchCall(url, { headers, method: this.method, body });

--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -180,6 +180,7 @@ describe('SparqlEndpointFetcher', () => {
         const headers: Headers = new Headers();
         headers.append('Accept', 'myacceptheader');
         headers.append('Content-Type', 'application/x-www-form-urlencoded');
+        headers.append('Content-Length', '43');
         const body = new URLSearchParams();
         body.set('query', querySelect);
         return expect(fetchCbThis).toBeCalledWith(


### PR DESCRIPTION
* Fix comunica/comunica#838 for SPARQL endpoints that require the  Content-Length header to be present.
* node-fetch has some functionality to set the Content-Length header (https://github.com/node-fetch/node-fetch/blob/ffef5e3c2322e8493dd75120b1123b01b106ab23/src/body.js#L329) but that doesn’t support URLSearchParams that is used here.
