### PR TITLE
use default export of 'abort-controller' for browser compatibility

### DIFF
--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -1,5 +1,5 @@
 import "cross-fetch/polyfill";
-import { AbortController } from 'abort-controller';
+import AbortController from 'abort-controller';
 import * as RDF from "@rdfjs/types";
 import {InsertDeleteOperation, ManagementOperation, Parser as SparqlParser} from "sparqljs";
 import {ISettings, SparqlJsonParser} from "sparqljson-parse";


### PR DESCRIPTION
fixes rubensworks/fetch-sparql-endpoint.js#43

Relates to [this known issue](https://github.com/mysticatea/abort-controller/issues/32) in [abort-controller](https://github.com/mysticatea/abort-controller). There are open PRs (like [#22](https://github.com/mysticatea/abort-controller/pull/22)) for fixing this inside [abort-controller](https://github.com/mysticatea/abort-controller).
