### PR TITLE
Allow additional url parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,9 @@ const myFetcher = new SparqlEndpointFetcher();
 
 Optionally, you can pass an options object with the following optional entries:
 ```js
-const additionalUrlParams = new URLSearchParams({'infer': 'true', 'sameAs': 'false'});
-
 const myFetcher = new SparqlEndpointFetcher({
   method: 'POST',                           // A custom HTTP method for issuing (non-update) queries, defaults to POST. Update queries are always issued via POST.
-  additionalUrlParams: additionalUrlParams  // A set of additional parameters that well be added to fetchAsk, fetchBindings & fetchTriples requests
+  additionalUrlParams: new URLSearchParams({'infer': 'true', 'sameAs': 'false'});  // A set of additional parameters that well be added to fetchAsk, fetchBindings & fetchTriples requests
   fetch: fetch,                             // A custom fetch-API-supporting function
   dataFactory: DataFactory,                 // A custom RDFJS data factory
   prefixVariableQuestionMark: false         // If variable names in bindings should be prefixed with '?', defaults to false

--- a/README.md
+++ b/README.md
@@ -39,11 +39,14 @@ const myFetcher = new SparqlEndpointFetcher();
 
 Optionally, you can pass an options object with the following optional entries:
 ```js
+const additionalUrlParams = new URLSearchParams({'infer': 'true', 'sameAs': 'false'});
+
 const myFetcher = new SparqlEndpointFetcher({
-  method: 'POST',                   // A custom HTTP method for issuing (non-update) queries, defaults to POST. Update queries are always issued via POST.
-  fetch: fetch,                     // A custom fetch-API-supporting function
-  dataFactory: DataFactory,         // A custom RDFJS data factory
-  prefixVariableQuestionMark: false // If variable names in bindings should be prefixed with '?', defaults to false
+  method: 'POST',                           // A custom HTTP method for issuing (non-update) queries, defaults to POST. Update queries are always issued via POST.
+  additionalUrlParams: additionalUrlParams  // A set of additional parameters that well be added to fetchAsk, fetchBindings & fetchTriples requests
+  fetch: fetch,                             // A custom fetch-API-supporting function
+  dataFactory: DataFactory,                 // A custom RDFJS data factory
+  prefixVariableQuestionMark: false         // If variable names in bindings should be prefixed with '?', defaults to false
 });
 ```
 

--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -185,7 +185,7 @@ export class SparqlEndpointFetcher {
       body = new URLSearchParams();
       body.set('query', query);
       this.additionalUrlParams.forEach((key: string, value: string) => {
-        body.set(key, String(value));
+        body.set(key, value);
       })
       headers.append('Content-Length', body.toString().length.toString());
     } else if (this.additionalUrlParams.toString() !== '') {

--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -25,6 +25,7 @@ export class SparqlEndpointFetcher {
   public static CONTENTTYPE_TURTLE: string = 'text/turtle';
 
   public readonly method: 'POST' | 'GET';
+  public readonly additionalUrlParams?: URLSearchParams;
   public readonly fetchCb?: (input?: Request | string, init?: RequestInit) => Promise<Response>;
   public readonly sparqlParsers: {[contentType: string]: ISparqlResultsParser};
   public readonly sparqlJsonParser: SparqlJsonParser;
@@ -33,6 +34,7 @@ export class SparqlEndpointFetcher {
   constructor(args?: ISparqlEndpointFetcherArgs) {
     args = args || {};
     this.method = args.method || 'POST';
+    this.additionalUrlParams = args.additionalUrlParams || new URLSearchParams();
     this.fetchCb = args.fetch;
     this.sparqlJsonParser = new SparqlJsonParser(args);
     this.sparqlXmlParser = new SparqlXmlParser(args);
@@ -172,17 +174,22 @@ export class SparqlEndpointFetcher {
    */
   public async fetchRawStream(endpoint: string, query: string, acceptHeader: string)
     : Promise<[string, NodeJS.ReadableStream]> {
-    const url: string = this.method === 'POST' ? endpoint : endpoint + '?query=' + encodeURIComponent(query);
+    let url: string = this.method === 'POST' ? endpoint : endpoint + '?query=' + encodeURIComponent(query);
 
     // Initiate request
     const headers: Headers = new Headers();
-    let body: BodyInit | undefined;
+    let body: URLSearchParams | undefined;
     headers.append('Accept', acceptHeader);
     if (this.method === 'POST') {
       headers.append('Content-Type', 'application/x-www-form-urlencoded');
       body = new URLSearchParams();
       body.set('query', query);
+      this.additionalUrlParams.forEach((key: string, value: string) => {
+        body.set(key, String(value));
+      })
       headers.append('Content-Length', body.toString().length.toString());
+    } else if (this.additionalUrlParams.toString() !== '') {
+      url += `&${this.additionalUrlParams.toString()}`;
     }
 
     return this.handleFetchCall(url, { headers, method: this.method, body });
@@ -238,6 +245,7 @@ export interface ISparqlEndpointFetcherArgs extends ISettings {
    * Update queries are always issued via POST.
    */
   method?: 'POST' | 'GET';
+  additionalUrlParams?: URLSearchParams;
   /**
    * A custom fetch function.
    */

--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -25,7 +25,7 @@ export class SparqlEndpointFetcher {
   public static CONTENTTYPE_TURTLE: string = 'text/turtle';
 
   public readonly method: 'POST' | 'GET';
-  public readonly additionalUrlParams?: URLSearchParams;
+  public readonly additionalUrlParams: URLSearchParams;
   public readonly fetchCb?: (input?: Request | string, init?: RequestInit) => Promise<Response>;
   public readonly sparqlParsers: {[contentType: string]: ISparqlResultsParser};
   public readonly sparqlJsonParser: SparqlJsonParser;

--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -175,6 +175,20 @@ describe('SparqlEndpointFetcher', () => {
     describe('#fetchRawStream', () => {
       it('should pass the correct URL and HTTP headers', () => {
         const fetchCbThis = jest.fn(() => Promise.resolve(new Response(streamifyString('dummy'))));
+        const fetcherThis = new SparqlEndpointFetcher({ fetch: fetchCbThis });
+        fetcherThis.fetchRawStream(endpoint, querySelect, 'myacceptheader');
+        const headers: Headers = new Headers();
+        headers.append('Accept', 'myacceptheader');
+        headers.append('Content-Type', 'application/x-www-form-urlencoded');
+        headers.append('Content-Length', '43');
+        const body = new URLSearchParams();
+        body.set('query', querySelect);
+        return expect(fetchCbThis).toBeCalledWith(
+          'https://dbpedia.org/sparql', { headers, method: 'POST', body });
+      });
+
+      it('should pass the correct URL and HTTP headers with additional URL parameters', () => {
+        const fetchCbThis = jest.fn(() => Promise.resolve(new Response(streamifyString('dummy'))));
         const additionalUrlParams = new URLSearchParams({'infer': 'true', 'sameAs': 'false'});
         const fetcherThis = new SparqlEndpointFetcher({ fetch: fetchCbThis, additionalUrlParams });
         fetcherThis.fetchRawStream(endpoint, querySelect, 'myacceptheader');


### PR DESCRIPTION
Implements #45

- Implemented in Don't see how this can be added to `fetchRawStream`. This does cover `fetchAsk`, `fetchBindings` & `fetchTriples`, but `fetchUpdate` is still ignored. Since it wasn't fully clear what the body should be in this case, I decided to leave out `fetchUpdate` for now.
- Type definitions for URLSearchParams seems less complete and less flexible than https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams describes. I decided to stick with what the type definitions do allow for.
- Please check if the tests make sense like this.