### PR TITLE
Add default headers to constructor

### DIFF
--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -26,6 +26,7 @@ export class SparqlEndpointFetcher {
 
   public readonly method: 'POST' | 'GET';
   public readonly additionalUrlParams: URLSearchParams;
+  public readonly defaultHeaders: Headers;
   public readonly fetchCb?: (input?: Request | string, init?: RequestInit) => Promise<Response>;
   public readonly sparqlParsers: {[contentType: string]: ISparqlResultsParser};
   public readonly sparqlJsonParser: SparqlJsonParser;
@@ -36,6 +37,7 @@ export class SparqlEndpointFetcher {
     args = args || {};
     this.method = args.method || 'POST';
     this.additionalUrlParams = args.additionalUrlParams || new URLSearchParams();
+    this.defaultHeaders = args.defaultHeaders || new Headers()
     this.fetchCb = args.fetch;
     this.sparqlJsonParser = new SparqlJsonParser(args);
     this.sparqlXmlParser = new SparqlXmlParser(args);
@@ -154,6 +156,7 @@ export class SparqlEndpointFetcher {
     const init: RequestInit = {
       method: 'POST',
       headers: {
+        ...this.defaultHeaders,
         'content-type': 'application/sparql-update',
       },
       body: query,
@@ -179,7 +182,7 @@ export class SparqlEndpointFetcher {
     let url: string = this.method === 'POST' ? endpoint : endpoint + '?query=' + encodeURIComponent(query);
 
     // Initiate request
-    const headers: Headers = new Headers();
+    const headers: Headers = new Headers(this.defaultHeaders);
     let body: URLSearchParams | undefined;
     headers.append('Accept', acceptHeader);
     if (this.method === 'POST') {
@@ -256,6 +259,7 @@ export interface ISparqlEndpointFetcherArgs extends ISettings {
   method?: 'POST' | 'GET';
   additionalUrlParams?: URLSearchParams;
   timeout?: number;
+  defaultHeaders?: Headers;
   /**
    * A custom fetch function.
    */

--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -186,6 +186,25 @@ describe('SparqlEndpointFetcher', () => {
           'https://dbpedia.org/sparql', expect.objectContaining({ headers, method: 'POST', body }));
       });
 
+      it('should pass the correct URL and HTTP headers with default headers', () => {
+        const fetchCbThis = jest.fn(() => Promise.resolve(new Response(streamifyString('dummy'))));
+        const defaultHeaders: Headers = new Headers();
+        defaultHeaders.append('Authorization', 'mytoken')
+        defaultHeaders.append('Accept', 'mydefaultacceptheader')
+        const fetcherThis = new SparqlEndpointFetcher({ fetch: fetchCbThis, defaultHeaders});
+        fetcherThis.fetchRawStream(endpoint, querySelect, 'myacceptheader');
+        const headers: Headers = new Headers();
+        headers.append('Accept', 'mydefaultacceptheader');
+        headers.append('Accept', 'myacceptheader');
+        headers.append('Content-Type', 'application/x-www-form-urlencoded');
+        headers.append('Content-Length', '43');
+        headers.append('Authorization', 'mytoken')
+        const body = new URLSearchParams();
+        body.set('query', querySelect);
+        return expect(fetchCbThis).toBeCalledWith(
+          'https://dbpedia.org/sparql', { headers, method: 'POST', body });
+      });
+
       it('should pass the correct URL and HTTP headers with additional URL parameters', () => {
         const fetchCbThis = jest.fn(() => Promise.resolve(new Response(streamifyString('dummy'))));
         const additionalUrlParams = new URLSearchParams({'infer': 'true', 'sameAs': 'false'});


### PR DESCRIPTION
Adds support for custom headers as proposed in #53. From looking at the existing code, I positioned the change as default headers that get overridden when actually fetching.

I was also wondering whether `acceptHeader` in https://github.com/rubensworks/fetch-sparql-endpoint.js/blob/master/lib/SparqlEndpointFetcher.ts#L177 should not better generalized to an optional customHeaders object?