### PR TITLE
`fetch()`'s `input` argument is not optional

### DIFF
--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -27,7 +27,7 @@ export class SparqlEndpointFetcher {
   public readonly method: 'POST' | 'GET';
   public readonly additionalUrlParams: URLSearchParams;
   public readonly defaultHeaders: Headers;
-  public readonly fetchCb?: (input?: Request | string, init?: RequestInit) => Promise<Response>;
+  public readonly fetchCb?: (input: Request | string, init?: RequestInit) => Promise<Response>;
   public readonly sparqlParsers: {[contentType: string]: ISparqlResultsParser};
   public readonly sparqlJsonParser: SparqlJsonParser;
   public readonly sparqlXmlParser: SparqlXmlParser;
@@ -267,7 +267,7 @@ export interface ISparqlEndpointFetcherArgs extends ISettings {
   /**
    * A custom fetch function.
    */
-  fetch?: (input?: Request | string, init?: RequestInit) => Promise<Response>;
+  fetch?: (input: Request | string, init?: RequestInit) => Promise<Response>;
 }
 
 export interface IBindings {


### PR DESCRIPTION
It's not optional in the browser DOM signature which this is emulating, and it's not clear what the behavior of a `fetch()` should be if it were given `undefined`. Type-wise, making this optional requires any client code providing a `fetch()` function to handle the `undefined` value, even though it's nonsensical.

See also https://github.com/comunica/comunica/pull/1233: Comunica's `fetch()` implementations don't accept `undefined`, but it wasn't breaking because `"strictFunctionTypes": false` was ignoring the errors.