### PR TITLE
Enable SPARQL* support for `getQueryType`

### DIFF
--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -32,6 +32,7 @@ export class SparqlEndpointFetcher {
   public readonly sparqlJsonParser: SparqlJsonParser;
   public readonly sparqlXmlParser: SparqlXmlParser;
   public readonly timeout: number;
+  public readonly sparqlStar: boolean;
 
   constructor(args?: ISparqlEndpointFetcherArgs) {
     args = args || {};
@@ -56,6 +57,7 @@ export class SparqlEndpointFetcher {
       },
     };
     this.timeout = args.timeout;
+    this.sparqlStar = args.sparqlStar || true;
   }
 
   /**
@@ -81,7 +83,7 @@ export class SparqlEndpointFetcher {
    * @return {'UNKNOWN' | UpdateTypes} The included update operations.
    */
   public getUpdateTypes(query: string): 'UNKNOWN' | IUpdateTypes {
-    const parsedQuery = new SparqlParser().parse(query);
+    const parsedQuery = new SparqlParser({sparqlStar: this.sparqlStar}).parse(query);
 
     if (parsedQuery.type === 'update') {
       const operations: IUpdateTypes = {};
@@ -264,6 +266,7 @@ export interface ISparqlEndpointFetcherArgs extends ISettings {
   additionalUrlParams?: URLSearchParams;
   timeout?: number;
   defaultHeaders?: Headers;
+  sparqlStar?: boolean;
   /**
    * A custom fetch function.
    */

--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -32,7 +32,6 @@ export class SparqlEndpointFetcher {
   public readonly sparqlJsonParser: SparqlJsonParser;
   public readonly sparqlXmlParser: SparqlXmlParser;
   public readonly timeout: number;
-  public readonly sparqlStar: boolean;
 
   constructor(args?: ISparqlEndpointFetcherArgs) {
     args = args || {};
@@ -57,7 +56,6 @@ export class SparqlEndpointFetcher {
       },
     };
     this.timeout = args.timeout;
-    this.sparqlStar = args.sparqlStar || true;
   }
 
   /**
@@ -83,7 +81,7 @@ export class SparqlEndpointFetcher {
    * @return {'UNKNOWN' | UpdateTypes} The included update operations.
    */
   public getUpdateTypes(query: string): 'UNKNOWN' | IUpdateTypes {
-    const parsedQuery = new SparqlParser({sparqlStar: this.sparqlStar}).parse(query);
+    const parsedQuery = new SparqlParser({sparqlStar: true}).parse(query);
 
     if (parsedQuery.type === 'update') {
       const operations: IUpdateTypes = {};
@@ -266,7 +264,6 @@ export interface ISparqlEndpointFetcherArgs extends ISettings {
   additionalUrlParams?: URLSearchParams;
   timeout?: number;
   defaultHeaders?: Headers;
-  sparqlStar?: boolean;
   /**
    * A custom fetch function.
    */

--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -67,7 +67,7 @@ export class SparqlEndpointFetcher {
    * @return {"SELECT" | "ASK" | "CONSTRUCT" | "UNKNOWN"} The query type.
    */
   public getQueryType(query: string): "SELECT" | "ASK" | "CONSTRUCT" | "UNKNOWN" {
-    const parsedQuery = new SparqlParser().parse(query);
+    const parsedQuery = new SparqlParser({sparqlStar: true}).parse(query);
     return parsedQuery.type === 'query'
       ? (parsedQuery.queryType === 'DESCRIBE' ? 'CONSTRUCT' : parsedQuery.queryType) : "UNKNOWN";
   }

--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -28,6 +28,7 @@ describe('SparqlEndpointFetcher', () => {
     const queryDescribe = 'DESCRIBE <http://ex.org>';
     const queryDelete = 'DELETE WHERE { ?s ?p ?o }';
     const queryInsert = 'INSERT { ?s ?p ?o } WHERE {}';
+    const queryInsertStar = 'INSERT { << ?si ?pi ?oi >> ?p ?o } WHERE {}';
     const updateDeleteData = prefixes + 'DELETE DATA { GRAPH <http://example.org/g1> { :a foaf:knows :b } }';
     const updateDeleteData2 = prefixes + 'DELETE DATA { GRAPH <http://example.org/g1> { :b foaf:knows :c } }';
     const updateInsertData = prefixes + 'INSERT DATA { GRAPH <http://example.org/g1> { :Alice foaf:knows :Bob } }';
@@ -99,6 +100,12 @@ describe('SparqlEndpointFetcher', () => {
 
       it('should detect an insertdelete query', () => {
         return expect(fetcher.getUpdateTypes(queryInsert)).toEqual({
+          insertdelete: true
+        });
+      });
+
+      it('should detect an insertdelete query on star', () => {
+        return expect(fetcher.getUpdateTypes(queryInsertStar)).toEqual({
           insertdelete: true
         });
       });

--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -76,6 +76,10 @@ describe('SparqlEndpointFetcher', () => {
         return expect(fetcher.getQueryType(queryDelete)).toEqual('UNKNOWN');
       });
 
+      it('should detect an unknown query', () => {
+        return expect(fetcher.getQueryType(queryDeleteStar)).toEqual('UNKNOWN');
+      });
+
       it('should throw an error on invalid queries', () => {
         return expect(() => fetcher.getQueryType('{{{')).toThrow();
       });

--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -27,11 +27,15 @@ describe('SparqlEndpointFetcher', () => {
     const queryConstruct = 'CONSTRUCT WHERE { ?s ?p ?o }';
     const queryDescribe = 'DESCRIBE <http://ex.org>';
     const queryDelete = 'DELETE WHERE { ?s ?p ?o }';
+    const queryDeleteStar = 'DELETE WHERE { << ?si ?pi ?oi >> ?p ?o }';
     const queryInsert = 'INSERT { ?s ?p ?o } WHERE {}';
     const queryInsertStar = 'INSERT { << ?si ?pi ?oi >> ?p ?o } WHERE {}';
     const updateDeleteData = prefixes + 'DELETE DATA { GRAPH <http://example.org/g1> { :a foaf:knows :b } }';
+    const updateDeleteDataStar = prefixes + 'DELETE DATA { GRAPH <http://example.org/g1> { :a foaf:knows << :b foaf:knows :c >> } }';
     const updateDeleteData2 = prefixes + 'DELETE DATA { GRAPH <http://example.org/g1> { :b foaf:knows :c } }';
+    const updateDeleteData2Star = prefixes + 'DELETE DATA { GRAPH <http://example.org/g1> { :b foaf:knows << :c foaf:knows :d >> } }';
     const updateInsertData = prefixes + 'INSERT DATA { GRAPH <http://example.org/g1> { :Alice foaf:knows :Bob } }';
+    const updateInsertDataStar = prefixes + 'INSERT DATA { GRAPH <http://example.org/g1> { :Alice foaf:knows << :Bob foaf:knows :Carrol >> } }';
     const updateMove = prefixes + 'MOVE DEFAULT TO :g1';
     const updateAdd = 'ADD SILENT GRAPH <http://www.example.com/g1> TO DEFAULT'
 
@@ -104,7 +108,7 @@ describe('SparqlEndpointFetcher', () => {
         });
       });
 
-      it('should detect an insertdelete query on star', () => {
+      it('should detect an insertdelete query with star', () => {
         return expect(fetcher.getUpdateTypes(queryInsertStar)).toEqual({
           insertdelete: true
         });
@@ -116,8 +120,20 @@ describe('SparqlEndpointFetcher', () => {
         });
       });
 
+      it('should detect a delete query with star', () => {
+        return expect(fetcher.getUpdateTypes(queryDeleteStar)).toEqual({
+          deletewhere: true
+        });
+      });
+
       it('should detect a delete data query', () => {
         return expect(fetcher.getUpdateTypes(updateDeleteData)).toEqual({
+          delete: true
+        });
+      });
+
+      it('should detect a delete data query with star', () => {
+        return expect(fetcher.getUpdateTypes(updateDeleteDataStar)).toEqual({
           delete: true
         });
       });
@@ -128,8 +144,20 @@ describe('SparqlEndpointFetcher', () => {
         });
       });
 
+      it('should detect a delete data query for 2 update operations with star', () => {
+        return expect(fetcher.getUpdateTypes(updateDeleteDataStar + ';' + updateDeleteData2Star)).toEqual({
+          delete: true
+        });
+      });
+
       it('should detect an insert data query', () => {
         return expect(fetcher.getUpdateTypes(updateInsertData)).toEqual({
+          insert: true
+        });
+      });
+
+      it('should detect an insert data query with star', () => {
+        return expect(fetcher.getUpdateTypes(updateInsertDataStar)).toEqual({
           insert: true
         });
       });
@@ -141,8 +169,22 @@ describe('SparqlEndpointFetcher', () => {
         });
       });
 
+      it('should detect a combined insert and delete data query with star', () => {
+        return expect(fetcher.getUpdateTypes(updateInsertDataStar + ';' + updateDeleteDataStar)).toEqual({
+          insert: true,
+          delete: true
+        });
+      });
+
       it('should detect a combined insert and delete data query (2 delete queries)', () => {
         return expect(fetcher.getUpdateTypes(updateInsertData + ';' + updateDeleteData + ';' + updateDeleteData)).toEqual({
+          insert: true,
+          delete: true
+        });
+      });
+
+      it('should detect a combined insert and delete data query (2 delete queries) with star', () => {
+        return expect(fetcher.getUpdateTypes(updateInsertDataStar + ';' + updateDeleteDataStar + ';' + updateDeleteDataStar)).toEqual({
           insert: true,
           delete: true
         });


### PR DESCRIPTION
Completed fix for #68 so that update queries passed to `getQueryType` return `'UNKNOWN'` instead of throwing an error.