### PR TITLE
Drop support for Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
         os:
           - ubuntu-latest
         node-version:
-          - 16.x
           - 18.x
           - 20.x
     steps:

--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -1,4 +1,3 @@
-import 'cross-fetch/polyfill';
 import type { Readable } from 'node:stream';
 import type * as RDF from '@rdfjs/types';
 import { ReadableWebToNodeStream } from '@smessie/readable-web-to-node-stream';

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@types/n3": "^1.0.0",
     "@types/readable-stream": "^4.0.0",
     "@types/sparqljs": "^3.0.0",
-    "cross-fetch": "^4.0.0",
     "is-stream": "^2.0.0",
     "n3": "^1.0.0",
     "rdf-string": "^1.0.0",
@@ -75,7 +74,6 @@
     "ts-jest": "^29.0.0",
     "ts-loader": "^9.0.0",
     "typescript": "^5.0.0",
-    "web-streams-ponyfill": "^1.0.0",
     "webpack": "^5.0.0",
     "webpack-cli": "^5.0.0"
   },

--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -4,16 +4,11 @@ import arrayifyStream from 'arrayify-stream';
 import { DataFactory } from 'rdf-data-factory';
 import { SparqlEndpointFetcher } from '../lib/SparqlEndpointFetcher';
 
-const DF = new DataFactory();
-
-if (!globalThis.ReadableStream) {
-  // TODO: Remove this workaround and ponyfill when Node 16 support is dropped
-  globalThis.ReadableStream = require('web-streams-ponyfill').ReadableStream;
-}
-
 // The import of 'readable-stream-node-to-web' is down here because of the above workaround
 const readableStreamNodeToWeb = require('readable-stream-node-to-web');
 const streamifyString = require('streamify-string');
+
+const DF = new DataFactory();
 
 describe('SparqlEndpointFetcher', () => {
   describe('constructed without fetch callback', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1979,13 +1979,6 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
-cross-fetch@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
-  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
-  dependencies:
-    node-fetch "^2.6.12"
-
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -4516,13 +4509,6 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-fetch@^2.6.12:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
-  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -5711,11 +5697,6 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
@@ -5997,16 +5978,6 @@ watchpack@^2.4.0:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
-web-streams-ponyfill@^1.0.0:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz#0ae863cc5f7493903679f16b08cbf14d432b62f4"
-  integrity sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA==
-
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
 webpack-cli@^5.0.0:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.4.tgz#c8e046ba7eaae4911d7e71e2b25b776fcc35759b"
@@ -6069,14 +6040,6 @@ webpack@^5.0.0:
     terser-webpack-plugin "^5.3.10"
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This is a draft PR, follow-up after #74 and #76, to drop support for Node 16 from the library. Dropping support allows removing some polyfills, and with Node 16 being EOL since the second half of last year according to the documentation I found online, no one is probably using it anymore.

I will keep this as a draft until the other PRs are addressed, in case this needs to be rebased.