### PR TITLE
Add missing return statement to CLI

### DIFF
--- a/bin/fetch-sparql-endpoint.ts
+++ b/bin/fetch-sparql-endpoint.ts
@@ -13,7 +13,7 @@ async function getQuery(query?: string, file?: string): Promise<string> {
     return query;
   }
   if (file) {
-    readFileSync(file, { encoding: 'utf-8' });
+    return readFileSync(file, { encoding: 'utf-8' });
   }
   return streamToString(process.stdin);
 }


### PR DESCRIPTION
Here is a small set of changes to:
* Add the missing `return` statement in the CLI, that fixes #79 
* Fix the configuration for `husky` version 9, by adding the `.husky/pre-commit` script and removing the redundant entry from `package.json`
* Split the Jest configuration away from `package.json` to make it cleaner
* Bump dependencies (`eslint` and `typescript`)

Any feedback is welcome!