### PR TITLE
added the option to do a direct HTTP POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ const myFetcher = new SparqlEndpointFetcher({
   // A custom HTTP method for issuing (non-update) queries, defaults to POST. Update queries are always issued via POST.
   method: 'POST',
   // A set of additional parameters that well be added to fetchAsk, fetchBindings & fetchTriples requests
+  // With a GET request, these are encoded in the URL.
+  // With a POST request when directPost is true (see below), these are also encoded in the URL.
+  // With other POST requests, it's encoded in the body.
   additionalUrlParams: new URLSearchParams({ infer: 'true', sameAs: 'false' }),
   // Optional default headers that will be included in each request
   defaultHeaders: new Headers(),
@@ -56,8 +59,10 @@ const myFetcher = new SparqlEndpointFetcher({
   timeout: 5000,
   // If the url length is below this number, HTTP GET is used regardless of the value of this.method, defaults to 0.
   forceGetIfUrlLengthBelow: 600,
-  // Force usage of direct POST (body = query string), normally a POST with URL-encoded parameters is used, defaults to false.
-  forceDirectPost: false,
+  // If true, POST requests will be sent as application/sparql-query (unencoded query string).
+  // If false, POST requests will be sent as application/x-www-form-urlencoded (URL-encoded query string).
+  // Defaults to false.
+  directPost: false,
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ const myFetcher = new SparqlEndpointFetcher({
   timeout: 5000,
   // If the url length is below this number, HTTP GET is used regardless of the value of this.method, defaults to 0.
   forceGetIfUrlLengthBelow: 600,
+  // Force usage of direct POST (body = query string), normally a POST with URL-encoded parameters is used, defaults to false.
+  forceDirectPost: false,
 });
 ```
 

--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -21,6 +21,7 @@ export class SparqlEndpointFetcher {
   protected readonly method: 'GET' | 'POST';
   protected readonly timeout?: number;
   protected readonly forceGetIfUrlLengthBelow: number;
+  protected readonly forceDirectPost: boolean;
   public additionalUrlParams: URLSearchParams;
   protected readonly defaultHeaders: Headers;
   public readonly fetchCb?: (input: Request | string, init?: RequestInit) => Promise<Response>;
@@ -33,6 +34,7 @@ export class SparqlEndpointFetcher {
     this.method = args?.method ?? 'POST';
     this.timeout = args?.timeout;
     this.forceGetIfUrlLengthBelow = args?.forceGetIfUrlLengthBelow ?? 0;
+    this.forceDirectPost = args?.forceDirectPost ?? false;
     this.additionalUrlParams = args?.additionalUrlParams ?? new URLSearchParams();
     this.defaultHeaders = args?.defaultHeaders ?? new Headers();
     this.fetchCb = args?.fetch;
@@ -206,16 +208,24 @@ export class SparqlEndpointFetcher {
     }
 
     // Initiate request
-    let body: URLSearchParams | undefined;
+    let body: URLSearchParams | string | undefined;
     const headers: Headers = new Headers(this.defaultHeaders);
     headers.append('Accept', acceptHeader);
 
     if (method === 'POST') {
-      headers.append('Content-Type', 'application/x-www-form-urlencoded');
-      body = new URLSearchParams();
-      body.set('query', query);
-      for (const [ key, value ] of this.additionalUrlParams.entries()) {
-        body.set(key, value);
+      if (this.forceDirectPost) {
+        headers.append('Content-Type', 'application/sparql-query');
+        body = query;
+        if (this.additionalUrlParams.toString().length > 0) {
+          url += `?${this.additionalUrlParams.toString()}`;
+        }
+      } else {
+        headers.append('Content-Type', 'application/x-www-form-urlencoded');
+        body = new URLSearchParams();
+        body.set('query', query);
+        for (const [ key, value ] of this.additionalUrlParams.entries()) {
+          body.set(key, value);
+        }
       }
       headers.append('Content-Length', body.toString().length.toString());
     } else if (this.additionalUrlParams.toString().length > 0) {
@@ -283,6 +293,7 @@ export interface ISparqlEndpointFetcherArgs extends ISparqlJsonParserArgs, ISpar
   additionalUrlParams?: URLSearchParams;
   timeout?: number;
   forceGetIfUrlLengthBelow?: number;
+  forceDirectPost?: boolean;
   defaultHeaders?: Headers;
   /**
    * A custom fetch function.

--- a/lib/SparqlEndpointFetcher.ts
+++ b/lib/SparqlEndpointFetcher.ts
@@ -21,7 +21,7 @@ export class SparqlEndpointFetcher {
   protected readonly method: 'GET' | 'POST';
   protected readonly timeout?: number;
   protected readonly forceGetIfUrlLengthBelow: number;
-  protected readonly forceDirectPost: boolean;
+  protected readonly directPost: boolean;
   public additionalUrlParams: URLSearchParams;
   protected readonly defaultHeaders: Headers;
   public readonly fetchCb?: (input: Request | string, init?: RequestInit) => Promise<Response>;
@@ -34,7 +34,7 @@ export class SparqlEndpointFetcher {
     this.method = args?.method ?? 'POST';
     this.timeout = args?.timeout;
     this.forceGetIfUrlLengthBelow = args?.forceGetIfUrlLengthBelow ?? 0;
-    this.forceDirectPost = args?.forceDirectPost ?? false;
+    this.directPost = args?.directPost ?? false;
     this.additionalUrlParams = args?.additionalUrlParams ?? new URLSearchParams();
     this.defaultHeaders = args?.defaultHeaders ?? new Headers();
     this.fetchCb = args?.fetch;
@@ -213,7 +213,7 @@ export class SparqlEndpointFetcher {
     headers.append('Accept', acceptHeader);
 
     if (method === 'POST') {
-      if (this.forceDirectPost) {
+      if (this.directPost) {
         headers.append('Content-Type', 'application/sparql-query');
         body = query;
         if (this.additionalUrlParams.toString().length > 0) {
@@ -293,7 +293,7 @@ export interface ISparqlEndpointFetcherArgs extends ISparqlJsonParserArgs, ISpar
   additionalUrlParams?: URLSearchParams;
   timeout?: number;
   forceGetIfUrlLengthBelow?: number;
-  forceDirectPost?: boolean;
+  directPost?: boolean;
   defaultHeaders?: Headers;
   /**
    * A custom fetch function.

--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -337,6 +337,42 @@ describe('SparqlEndpointFetcher', () => {
         );
       });
 
+      it('should use direct HTTP POST when forceDirectPost is true', async() => {
+        const fetchCbThis = jest.fn(() => Promise.resolve(new Response(streamifyString('dummy'))));
+        const fetcherThis = new SparqlEndpointFetcher({
+          method: 'POST',
+          fetch: fetchCbThis,
+          forceDirectPost: true,
+        });
+        await fetcherThis.fetchRawStream(endpoint, querySelect, 'myacceptheader');
+        const headers: Headers = new Headers();
+        headers.append('Accept', 'myacceptheader');
+        const body = querySelect;
+        expect(fetchCbThis).toHaveBeenCalledWith(
+          'https://dbpedia.org/sparql',
+          expect.objectContaining({ headers, method: 'POST', body }),
+        );
+      });
+
+      it('should use direct HTTP POST when forceDirectPost is true with additional URL parameters', async() => {
+        const fetchCbThis = jest.fn(() => Promise.resolve(new Response(streamifyString('dummy'))));
+        const additionalUrlParams = new URLSearchParams({ infer: 'true', sameAs: 'false' });
+        const fetcherThis = new SparqlEndpointFetcher({
+          method: 'POST',
+          fetch: fetchCbThis,
+          forceDirectPost: true,
+          additionalUrlParams,
+        });
+        await fetcherThis.fetchRawStream(endpoint, querySelect, 'myacceptheader');
+        const headers: Headers = new Headers();
+        headers.append('Accept', 'myacceptheader');
+        const body = querySelect;
+        expect(fetchCbThis).toHaveBeenCalledWith(
+          'https://dbpedia.org/sparql?infer=true&sameAs=false',
+          expect.objectContaining({ headers, method: 'POST', body }),
+        );
+      });
+
       it('should reject for an invalid server response', async() => {
         const fetchCbThis = () => Promise.resolve(<Response> {
           body: streamifyString('this is an invalid response'),

--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -337,12 +337,12 @@ describe('SparqlEndpointFetcher', () => {
         );
       });
 
-      it('should use direct HTTP POST when forceDirectPost is true', async() => {
+      it('should use direct HTTP POST when directPost is true', async() => {
         const fetchCbThis = jest.fn(() => Promise.resolve(new Response(streamifyString('dummy'))));
         const fetcherThis = new SparqlEndpointFetcher({
           method: 'POST',
           fetch: fetchCbThis,
-          forceDirectPost: true,
+          directPost: true,
         });
         await fetcherThis.fetchRawStream(endpoint, querySelect, 'myacceptheader');
         const headers: Headers = new Headers();
@@ -354,13 +354,13 @@ describe('SparqlEndpointFetcher', () => {
         );
       });
 
-      it('should use direct HTTP POST when forceDirectPost is true with additional URL parameters', async() => {
+      it('should use direct HTTP POST when directPost is true with additional URL parameters', async() => {
         const fetchCbThis = jest.fn(() => Promise.resolve(new Response(streamifyString('dummy'))));
         const additionalUrlParams = new URLSearchParams({ infer: 'true', sameAs: 'false' });
         const fetcherThis = new SparqlEndpointFetcher({
           method: 'POST',
           fetch: fetchCbThis,
-          forceDirectPost: true,
+          directPost: true,
           additionalUrlParams,
         });
         await fetcherThis.fetchRawStream(endpoint, querySelect, 'myacceptheader');


### PR DESCRIPTION
[The specs](https://www.w3.org/TR/sparql11-protocol/#query-operation) define 2 POST possibilities, we had the query via POST with URL-encoded parameters and this one adds the query via POST directly. 
Of course if the method is GET, it won't force the direct HTTP POST.