### PR TITLE
test: regression coverage for multibyte request-body Content-Length (#96)

### DIFF
--- a/test/SparqlEndpointFetcher-test.ts
+++ b/test/SparqlEndpointFetcher-test.ts
@@ -251,7 +251,6 @@ describe('SparqlEndpointFetcher', () => {
         const headers: Headers = new Headers();
         headers.append('Accept', 'myacceptheader');
         headers.append('Content-Type', 'application/x-www-form-urlencoded');
-        headers.append('Content-Length', '43');
         const body = new URLSearchParams();
         body.set('query', querySelect);
         expect(fetchCbThis).toHaveBeenCalledWith(
@@ -288,7 +287,6 @@ describe('SparqlEndpointFetcher', () => {
         const headers: Headers = new Headers();
         headers.append('Accept', 'myacceptheader');
         headers.append('Content-Type', 'application/x-www-form-urlencoded');
-        headers.append('Content-Length', '67');
         const body = new URLSearchParams();
         body.set('query', querySelect);
         // eslint-disable-next-line unicorn/no-array-for-each
@@ -589,6 +587,69 @@ describe('SparqlEndpointFetcher', () => {
           undefined,
           streamifyString('abc'),
         ]);
+      });
+    });
+
+    describe('Content-Length for multibyte request bodies', () => {
+      // Regression test for
+      // https://github.com/rubensworks/fetch-sparql-endpoint.js/issues/96 (fixed in 71272ca).
+      // The manual Content-Length header used to be computed from the JS string length
+      // (UTF-16 code units) instead of the UTF-8 byte length. A query or update containing
+      // multibyte characters (accents, emoji, non-Latin scripts) therefore produced a
+      // too-small Content-Length, which can truncate the request body or be rejected by
+      // strict HTTP clients (e.g. undici). The fix drops the manual header and lets the
+      // fetch client compute the correct byte count. These tests guard that a
+      // byte-incorrect Content-Length is never sent again.
+
+      // 'é' encodes as 2 UTF-8 bytes and '😀' as 4, so byteLength > string length here.
+      const multibyteQuery = 'SELECT * WHERE { ?s ?p "café 😀" }';
+      const multibyteUpdate = 'INSERT DATA { <ex:s> <ex:p> "café 😀" }';
+
+      // Assert the request never carries a Content-Length equal to the (smaller) JS string
+      // length. Either the header is absent (the fetch client derives the correct length)
+      // or, if present, it equals the UTF-8 byte length of the body.
+      function expectNoStringLengthContentLength(headers: Headers, body: string): void {
+        expect(Buffer.byteLength(body)).toBeGreaterThan(body.length);
+        const contentLength = headers.get('content-length');
+        if (contentLength !== null) {
+          expect(Number(contentLength)).toBe(Buffer.byteLength(body));
+          expect(Number(contentLength)).not.toBe(body.length);
+        }
+      }
+
+      it('should not send a string-length Content-Length for a directPost query', async() => {
+        const fetchCbThis: jest.Mock<Promise<Response>, any[]> = jest
+          .fn(() => Promise.resolve(new Response(streamifyString('dummy'))));
+        const fetcherThis = new SparqlEndpointFetcher({ fetch: fetchCbThis, directPost: true });
+        await fetcherThis.fetchRawStream(endpoint, multibyteQuery, 'myacceptheader');
+        const init: RequestInit = fetchCbThis.mock.calls[0][1];
+        expectNoStringLengthContentLength(<Headers> init.headers, <string> init.body);
+      });
+
+      it('should not send a string-length Content-Length for an urlencoded query', async() => {
+        const fetchCbThis: jest.Mock<Promise<Response>, any[]> = jest
+          .fn(() => Promise.resolve(new Response(streamifyString('dummy'))));
+        const fetcherThis = new SparqlEndpointFetcher({ fetch: fetchCbThis });
+        await fetcherThis.fetchRawStream(endpoint, multibyteQuery, 'myacceptheader');
+        const init: RequestInit = fetchCbThis.mock.calls[0][1];
+        // The urlencoded body is percent-encoded to ASCII, so string length equals byte
+        // length; assert directly that no manual Content-Length is attached.
+        expect((<Headers> init.headers).get('content-length')).toBeNull();
+      });
+
+      it('should not send a string-length Content-Length for an update', async() => {
+        const fetchCbThis: jest.Mock<Promise<Response>, any[]> = jest.fn(() => Promise.resolve(<Response> {
+          body: {},
+          headers: new Headers(),
+          ok: true,
+          status: 200,
+          statusText: 'Ok!',
+        }));
+        const fetcherThis = new SparqlEndpointFetcher({ fetch: fetchCbThis });
+        await fetcherThis.fetchUpdate(endpoint, multibyteUpdate);
+        const init: RequestInit = fetchCbThis.mock.calls[0][1];
+        const headers = new Headers(<Record<string, string>> init.headers);
+        expectNoStringLengthContentLength(headers, <string> init.body);
       });
     });
 


### PR DESCRIPTION
> **This is an agent-generated draft PR**, opened by @jeswr's AI agent as part of an ecosystem performance/correctness investigation. It is intentionally left as a **draft**. @jeswr will review and finalize it, and will tag the maintainer when it is ready — please don't action it before then.

## What this is

A **test-only** follow-up to the already-merged fix in #97 (`71272ca`, "Don't set Content-Length header manually", closing #96).

That fix correctly stopped setting the manual `Content-Length` header, but it did not add a regression test for the behaviour, and it left two now-stale `Content-Length` assertions behind in the `fetchRawStream` tests (it removed one of the three). This PR adds the missing regression coverage and removes the stale assertions. **No library source is touched.**

## Background — the two bugs #96 addressed

The manual header was computed as `body.toString().length` — the JS **string length** (UTF-16 code units), not the UTF-8 **byte length**. This had two failure modes:

1. **Wrong byte count for multibyte bodies** (correctness). In `directPost` mode the body is the raw query string, so any multibyte character (accents, emoji, non-Latin scripts) made the declared `Content-Length` smaller than the real body, which can truncate the request.
2. **Forbidden-header rejection under undici** (compat). `Content-Length` is a forbidden request header; when it survives a foreign-dispatcher hand-off, undici 7+ rejects it with `UND_ERR_INVALID_ARG: invalid content-length header` (the original #96 report).

Note a subtlety worth recording: in the **default** (`application/x-www-form-urlencoded`) path the body is a `URLSearchParams`, whose `.toString()` percent-encodes to pure ASCII — so there string length *does* equal byte length, and only failure mode (2) applied. Failure mode (1) was specific to the raw-string paths (`directPost`, and any future raw-body path).

## Reproduction / measured numbers

Fixture query with a 2-byte `é` and a 4-byte `😀`: `SELECT * WHERE { ?s ?p "café 😀" }`.

To confirm the new tests actually guard the bug, the pre-#96 line (`headers.append('Content-Length', body.toString().length.toString())`) was temporarily re-introduced and the new tests re-run:

| New test | Against pre-#96 code | Against current master |
|---|---|---|
| directPost query | **FAIL** — declared `Content-Length` = `34` (string length) vs actual `37` bytes (a 3-byte under-count) | pass (no manual header; client computes `37`) |
| urlencoded query | **FAIL** — a manual `Content-Length: 67` is attached at all (the header undici 7 rejects) | pass (`content-length` is `null`) |
| update (`fetchUpdate`) | pass (this path never set the header) — forward-looking guard | pass |

So the directPost/urlencoded tests fail on the buggy code and pass on the fixed code, i.e. they are genuine regression guards for #96.

## Test results

```
Test Suites: 1 passed, 1 total
Tests:       85 passed, 85 total   (82 baseline + 3 new)
Coverage:    SparqlEndpointFetcher.ts 100% stmts / 100% branch / 100% funcs / 100% lines
Lint:        eslint clean
Build:       tsc clean
```

Node v22, `yarn install --frozen-lockfile` + `yarn jest` / `yarn lint` / `yarn build`.

## Changes

- `test/SparqlEndpointFetcher-test.ts`
  - New `describe('Content-Length for multibyte request bodies')` block: asserts a multibyte query/update never carries a `Content-Length` equal to the JS string length (covers the `directPost`, urlencoded, and `fetchUpdate` paths).
  - Removed two stale `headers.append('Content-Length', …)` lines from the `fetchRawStream` header tests — the code no longer sends that header, and under the `expect.objectContaining({ headers })` + `Headers` matcher those lines were not actually being verified (they passed whether or not the header was present).

---

cc @jeswr — agent-generated; please review, finalize, and tag the maintainer when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
