### PR TITLE
Update dependency @types/node to v24

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@rubensworks/eslint-config": "^3.0.0",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^24.0.0",
     "arrayify-stream": "^3.0.0",
     "coveralls": "^3.0.0",
     "eslint": "^8.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "es6",
     "lib": [
-      "es6",
+      "es2022",
       "dom"
     ],
     "module": "commonjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,12 +1341,12 @@
   dependencies:
     undici-types "~6.20.0"
 
-"@types/node@^20.0.0":
-  version "20.19.37"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.37.tgz#b4fb4033408dd97becce63ec932c9ec57a9e2919"
-  integrity sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==
+"@types/node@^24.0.0":
+  version "24.13.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.13.3.tgz#49f18bd3c647866dcda51a0756c145e14590ce16"
+  integrity sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==
   dependencies:
-    undici-types "~6.21.0"
+    undici-types "~7.18.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -6645,10 +6645,10 @@ undici-types@~6.20.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
Supersedes #95 by carrying the Renovate `@types/node` v20 → v24 bump together with the one source change it needs to build.

## Why #95 fails

`@types/node` v20 shipped ambient `RelativeIndexable` declarations:

```ts
interface RelativeIndexable<T> { at(index: number): T | undefined }
interface Array<T> extends RelativeIndexable<T> {}
```

Those added `Array.prototype.at` / `String.prototype.at` to the type graph regardless of the configured `lib`. v24 dropped them, so the two existing `.at(0)` calls in `lib/SparqlEndpointFetcher.ts` no longer resolved under `"lib": ["es6", "dom"]`:

```
lib/SparqlEndpointFetcher.ts(293,40): error TS2550: Property 'at' does not exist on type 'string[]'.
  Do you need to change your target library? Try changing the 'lib' compiler option to 'es2022' or later.
lib/SparqlEndpointFetcher.ts(300,47): error TS2550: Property 'at' does not exist on type 'string[]'.
```

ESLint surfaced the same thing as the two `ts/no-unsafe-assignment` errors on the `lint` job — unresolved property accesses come back as `any`, so the lint failure was a symptom of the compile error rather than a separate problem.

## Change

Raise `lib` in `tsconfig.json` from `es6` to `es2022`, which is where `.at` is actually declared. Emit `target` stays at `es6`, so the compiled output is unchanged.

This makes the declared lib match what the code was already relying on — `.at` was being used before this PR too, it was just being type-declared by `@types/node` instead of by the lib.

## Verification

Ran all four CI jobs locally against `@types/node` 24.13.3:

- `yarn lint` — clean
- `yarn build` (`tsc`) — clean
- `yarn test` — 82 passed, 100% coverage
- `npx webpack` — compiled successfully

---
_Generated by [Claude Code](https://claude.ai/code/session_011NWJx7bmtxH641k6zw1tYR)_